### PR TITLE
On cell firing tracking

### DIFF
--- a/cli/cmd/train.go
+++ b/cli/cmd/train.go
@@ -78,7 +78,7 @@ func Train(networkInputFile, networkSaveFile, vocabSaveFile, testDataFile, doPro
 	go func() {
 		<-c
 		now := strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
-		err = vocab.SaveToFile(vocabSaveFile)
+		err = vocab.SaveToFile("vocab_" + now + ".json")
 		if err != nil {
 			fmt.Println("Failed saving vocab")
 			fmt.Println(err)

--- a/laws/laws.go
+++ b/laws/laws.go
@@ -32,7 +32,7 @@ const NewSynapseMinMillivolts int = -30
 NewSynapseMaxMillivolts is the bottom range of how much a new synapse will
 have for the `Millivolts` property.
 */
-const NewSynapseMaxMillivolts int = 30
+const NewSynapseMaxMillivolts int = 100
 
 /*
 SynapseLearnRate is how much a synapse should get bumped when it is being reinforced.
@@ -87,7 +87,7 @@ the pattern. A network will get seeded with some initial cells to fire,
 then it will keep firing (stepping) while we record what gets fired.
 If it doesn't fizzle out on its own, it will stop at MaxPostFireSteps.
 */
-const MaxPostFireSteps uint8 = 20
+const MaxPostFireSteps int = 20
 
 /*
 FiringIterationsPerSample is how many times to fire an input cell.

--- a/laws/laws.go
+++ b/laws/laws.go
@@ -32,7 +32,7 @@ const NewSynapseMinMillivolts int = -30
 NewSynapseMaxMillivolts is the bottom range of how much a new synapse will
 have for the `Millivolts` property.
 */
-const NewSynapseMaxMillivolts int = 100
+const NewSynapseMaxMillivolts int = 60
 
 /*
 SynapseLearnRate is how much a synapse should get bumped when it is being reinforced.
@@ -53,7 +53,7 @@ const CellRestingVoltage int16 = -10
 /*
 CellFireVoltageThreshold represents the millivolts where an action potential will result.
 */
-const CellFireVoltageThreshold int = 100
+const CellFireVoltageThreshold int = 240
 
 /*
 DefaultNeuronSynapses is the number of random synapses a new neuron will get.
@@ -87,14 +87,14 @@ the pattern. A network will get seeded with some initial cells to fire,
 then it will keep firing (stepping) while we record what gets fired.
 If it doesn't fizzle out on its own, it will stop at MaxPostFireSteps.
 */
-const MaxPostFireSteps int = 20
+const MaxPostFireSteps int = 5
 
 /*
 FiringIterationsPerSample is how many times to fire an input cell.
 Firing once may not cause much firing in the network. So firing
 10 or 100+ times in a row will excite many pathways.
 */
-const FiringIterationsPerSample int = 10
+const FiringIterationsPerSample int = 5
 
 /*
 PatternSimilarityLimit represents the percentage/ratio of

--- a/potential/cell.go
+++ b/potential/cell.go
@@ -160,3 +160,12 @@ func (network *Network) PruneCell(cellID CellID) {
 	network.Cells[cellID] = nil
 	network.cellMux.Unlock()
 }
+
+/*
+postRefractoryReset does things that happen after a cell has been through
+the refractory period after it fired.
+*/
+func (cell *Cell) postRefractoryReset() {
+	cell.activating = false
+	cell.Voltage = laws.CellRestingVoltage
+}

--- a/potential/cell.go
+++ b/potential/cell.go
@@ -47,7 +47,10 @@ type Cell struct {
 	*/
 	AxonSynapses map[SynapseID]bool
 	/*
-	  WasFired is used during training to know if this cell fired during the session
+	  WasFired is used during training to know if this cell fired during the session.
+	  TODO: may no longer be necessary because 1) activating property might handle
+	  this, and 2) only used during backtracing which is dead code at the time of
+	  writing.
 	*/
 	WasFired bool
 	/*
@@ -87,10 +90,11 @@ func NewCell(network *Network) *Cell {
 
 /*
 FireActionPotential does an action potential cycle.
+
+`cell.activating` property is set in `Step()`
 */
 func (cell *Cell) FireActionPotential() {
 	cell.WasFired = true
-	cell.activating = true
 	// fmt.Println("Action Potential Firing\n  cell=", cell.ID, "synapses=", len(cell.AxonSynapses))
 
 	for _, cb := range cell.OnFired {

--- a/potential/cell_test.go
+++ b/potential/cell_test.go
@@ -34,6 +34,31 @@ func Test_NewCell(t *testing.T) {
 	})
 }
 
+func Test_CellFireAP(t *testing.T) {
+	t.Run("firing cell results in its synapses having the fire-next flag set", func(t *testing.T) {
+		network := NewNetwork()
+		cell := NewCell(network)
+		receiverCell := NewCell(network)
+
+		// two synapses from cell to receiver
+		network.linkCells(cell.ID, receiverCell.ID)
+		network.linkCells(cell.ID, receiverCell.ID)
+
+		// pretest
+		assert.Equal(t, false, network.GetSyn(0).fireNextRound,
+			"bad initial fire state of synapse")
+		assert.Equal(t, false, network.GetSyn(1).fireNextRound,
+			"bad initial fire state of synapse")
+
+		// test
+		network.GetCell(0).FireActionPotential()
+		assert.Equal(t, true, network.GetSyn(0).fireNextRound,
+			"synapse should be flagged for firing next round")
+		assert.Equal(t, true, network.GetSyn(1).fireNextRound,
+			"synapse should be flagged for firing next round")
+	})
+}
+
 func Test_CellStringer(t *testing.T) {
 	t.Run("String works without crashing", func(t *testing.T) {
 		network := NewNetwork()

--- a/potential/diff_test.go
+++ b/potential/diff_test.go
@@ -26,15 +26,13 @@ func Test_CloneNetwork(t *testing.T) {
 		original := NewNetwork()
 
 		beforeCell := NewCell(original)
-		original.Cells[beforeCell.ID] = beforeCell
-		beforeCell.Network = original
 
 		cloned := CloneNetwork(original)
 		// change something
-		three := SynapseID(333)
-		cloned.nextSynapsesToActivate[three] = true
+		one := SynapseID(0)
+		cloned.Synapses[one].fireNextRound = true
 
-		if cloned.nextSynapsesToActivate[three] == original.nextSynapsesToActivate[three] {
+		if cloned.Synapses[one].fireNextRound == original.Synapses[one].fireNextRound {
 			t.Error("changing props of cloned network should not change original")
 		}
 

--- a/potential/diff_test.go
+++ b/potential/diff_test.go
@@ -26,17 +26,19 @@ func Test_CloneNetwork(t *testing.T) {
 		original := NewNetwork()
 
 		beforeCell := NewCell(original)
+		afterCell := NewCell(original)
+		original.linkCells(beforeCell.ID, afterCell.ID)
 
 		cloned := CloneNetwork(original)
 		// change something
 		one := SynapseID(0)
-		cloned.Synapses[one].fireNextRound = true
+		cloned.GetSyn(one).fireNextRound = true
 
-		if cloned.Synapses[one].fireNextRound == original.Synapses[one].fireNextRound {
+		if cloned.GetSyn(one).fireNextRound == original.GetSyn(one).fireNextRound {
 			t.Error("changing props of cloned network should not change original")
 		}
 
-		if &cloned.Cells[beforeCell.ID].Network == &original.Cells[beforeCell.ID].Network {
+		if &cloned.GetCell(beforeCell.ID).Network == &original.GetCell(beforeCell.ID).Network {
 			t.Error("cloned and original cells should not point to the same network")
 		}
 

--- a/potential/firingpattern.go
+++ b/potential/firingpattern.go
@@ -27,7 +27,7 @@ func FireNetworkUntilDone(network *Network, seedCells FiringPattern) (fp FiringP
 	fp = make(FiringPattern)
 	for cellID := range seedCells {
 		network.GetCell(cellID).FireActionPotential()
-		network.resetCellsOnNextStep[cellID] = true
+		network.Cells[cellID].activating = true
 	}
 	// we ignore the seedCells
 	for {
@@ -35,11 +35,14 @@ func FireNetworkUntilDone(network *Network, seedCells FiringPattern) (fp FiringP
 			break
 		}
 		hasMore := network.Step()
-		for cellID := range network.resetCellsOnNextStep {
-			if _, ok := fp[cellID]; !ok {
-				fp[cellID] = 0
+		for _cellID, cell := range network.Cells {
+			cellID := CellID(_cellID)
+			if cell.activating {
+				if _, ok := fp[cellID]; !ok {
+					fp[cellID] = 0
+				}
+				fp[cellID]++
 			}
-			fp[cellID]++
 		}
 		if !hasMore {
 			break

--- a/potential/firingpattern.go
+++ b/potential/firingpattern.go
@@ -53,7 +53,7 @@ func FireNetworkUntilDone(network *Network, seedCells FiringPattern) (fp FiringP
 }
 
 /*
-mergeFiringPatterns returns a new FiringPattern containing a mashup of
+mergeFiringPatterns returns a new FiringPattern containing an average of
 the two supplied patterns.
 */
 func mergeFiringPatterns(fp1, fp2 FiringPattern) (merged FiringPattern) {
@@ -64,7 +64,10 @@ func mergeFiringPatterns(fp1, fp2 FiringPattern) (merged FiringPattern) {
 	}
 	for cellID, fires := range fp2 {
 		if otherFires, already := merged[cellID]; already {
-			merged[cellID] = uint16(math.Floor(float64(otherFires + fires/2)))
+			combined := (otherFires + fires)
+			average := float64(combined / 2)
+			bottomValue := uint16(math.Floor(average))
+			merged[cellID] = bottomValue
 		} else {
 			merged[cellID] = fires
 		}

--- a/potential/firingpattern_test.go
+++ b/potential/firingpattern_test.go
@@ -36,10 +36,11 @@ func Test_FiringPattern(t *testing.T) {
 		result := FireNetworkUntilDone(network, cells)
 		fmt.Println(a.activating, b.activating, c.activating)
 		assert.Equal(t, 3, len(result), "wrong number of cells fired")
+		fmt.Println("result=", result)
 		assert.Equal(t, uint16(0), result[d.ID], "should not have fired this cell")
-		assert.Equal(t, uint16(6), result[a.ID], "did not fire cell: a")
-		assert.Equal(t, uint16(7), result[b.ID], "did not fire cell: b")
-		assert.Equal(t, uint16(7), result[c.ID], "did not fire cell: c")
+		assert.Equal(t, uint16(10), result[a.ID], "did not fire cell: a-0")
+		assert.Equal(t, uint16(10), result[b.ID], "did not fire cell: b-1")
+		assert.Equal(t, uint16(10), result[c.ID], "did not fire cell: c-2")
 	})
 }
 

--- a/potential/firingpattern_test.go
+++ b/potential/firingpattern_test.go
@@ -34,13 +34,13 @@ func Test_FiringPattern(t *testing.T) {
 		cells := make(FiringPattern)
 		cells[a.ID] = 1
 		result := FireNetworkUntilDone(network, cells)
-		fmt.Println(a.activating, b.activating, c.activating)
+		fmt.Println(a.WasFired, b.WasFired, c.WasFired)
 		assert.Equal(t, 3, len(result), "wrong number of cells fired")
 		fmt.Println("result=", result)
 		assert.Equal(t, uint16(0), result[d.ID], "should not have fired this cell")
-		assert.Equal(t, uint16(10), result[a.ID], "did not fire cell: a-0")
-		assert.Equal(t, uint16(10), result[b.ID], "did not fire cell: b-1")
-		assert.Equal(t, uint16(10), result[c.ID], "did not fire cell: c-2")
+		assert.Equal(t, uint16(3), result[a.ID], "did not fire cell: a-0")
+		assert.Equal(t, uint16(4), result[b.ID], "did not fire cell: b-1")
+		assert.Equal(t, uint16(3), result[c.ID], "did not fire cell: c-2")
 	})
 }
 
@@ -58,7 +58,8 @@ func Test_FiringDiffRatio(t *testing.T) {
 		fp2[CellID(1)] = 7
 
 		diff := DiffFiringPatterns(fp1, fp2)
-		assert.Equal(t, 1.0, diff)
+		r, _ := diff.Ratio()
+		assert.Equal(t, 1.0, r)
 	})
 	t.Run("totally different firing patterns have ratio of 0", func(t *testing.T) {
 		fp1 := make(FiringPattern)
@@ -71,7 +72,8 @@ func Test_FiringDiffRatio(t *testing.T) {
 		fp2[CellID(99)] = 4
 
 		diff := DiffFiringPatterns(fp1, fp2)
-		assert.Equal(t, 0.0, diff)
+		r, _ := diff.Ratio()
+		assert.Equal(t, 0.0, r)
 	})
 	t.Run("radio calculates the number of unrepresented fires to represented fires", func(t *testing.T) {
 		fp1 := make(FiringPattern)
@@ -89,10 +91,10 @@ func Test_FiringDiffRatio(t *testing.T) {
 		fp1[CellID(2)] = 4
 
 		diff := DiffFiringPatterns(fp1, fp2)
-
+		r, _ := diff.Ratio()
 		// (1 + 2 + 4) / (3 + 14 + 16 + 4)
 		tot := 2 + 16 + 4.0
-		assert.Equal(t, (tot-(1+2+4.0))/tot, diff)
+		assert.Equal(t, (tot-(1+2+4.0))/tot, r)
 	})
 }
 

--- a/potential/firingpattern_test.go
+++ b/potential/firingpattern_test.go
@@ -94,3 +94,27 @@ func Test_FiringDiffRatio(t *testing.T) {
 		assert.Equal(t, (tot-(1+2+4.0))/tot, diff)
 	})
 }
+
+func Test_FiringPatternMerge(t *testing.T) {
+	t.Run("merging firing patterns returns a new combined pattern", func(t *testing.T) {
+		fp1 := make(FiringPattern)
+		fp2 := make(FiringPattern)
+
+		// 1 different
+		fp1[CellID(0)] = 2
+		fp2[CellID(0)] = 1
+
+		// 2 different
+		fp1[CellID(1)] = 14
+		fp2[CellID(1)] = 16
+
+		// 4 different / unshared
+		fp1[CellID(2)] = 4
+
+		merged := mergeFiringPatterns(fp1, fp2)
+
+		assert.Equal(t, uint16(1), merged[CellID(0)])
+		assert.Equal(t, uint16(15), merged[CellID(1)])
+		assert.Equal(t, uint16(4), merged[CellID(2)])
+	})
+}

--- a/potential/firingvocab.go
+++ b/potential/firingvocab.go
@@ -122,5 +122,17 @@ func (vocab *Vocabulary) SaveToFile(filepath string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath, []byte(d), os.ModePerm)
+	return ioutil.WriteFile(filepath, d, os.ModePerm)
+}
+
+func (vocab *Vocabulary) printInputs() {
+	for k, v := range vocab.Inputs {
+		fmt.Println("Input:", k, v)
+	}
+}
+
+func (vocab *Vocabulary) printOutputs() {
+	for k, v := range vocab.Outputs {
+		fmt.Println("Output:", k, v)
+	}
 }

--- a/potential/firingvocabunit.go
+++ b/potential/firingvocabunit.go
@@ -62,13 +62,16 @@ func (vu *VocabUnit) InitRandomInputs(network *Network) {
 }
 
 /*
-expandInputs expands an input firing pattern by a set number of cells.
+expandInputs expands an input firing pattern by a set number of cells and uses
+an excitatory synapse to link them.
 */
 func expandInputs(network *Network, fp FiringPattern) {
 	for i := 0; i < laws.InputCellDifferentiationCount; i++ {
 		preCell := randCellFromFP(fp)
 		newCell := NewCell(network)
-		network.linkCells(preCell, newCell.ID)
+		newSynapse := network.linkCells(preCell, newCell.ID)
+		// excitatory
+		newSynapse.Millivolts = int16(math.Abs(float64(newSynapse.Millivolts)))
 		// fp[newCell.ID] = true
 	}
 }
@@ -87,13 +90,15 @@ func randCellFromFP(cellMap FiringPattern) (randCellID CellID) {
 }
 
 /*
-expandOutputs expands an output firing pattern by adding more synapses
-to new cells that are attached to random cells in its map.
+expandOutputs expands an output firing pattern by adding more INHIBITORY
+synapses to new cells that are attached to random cells in its map.
 */
 func expandOutputs(network *Network, noiseLevel float64, fp FiringPattern) {
 	noisyCellsToAdd := int(math.Ceil(noiseLevel * float64(len(fp))))
 	for i := 0; i < noisyCellsToAdd; i++ {
 		preCell := randCellFromFP(fp)
-		network.linkCells(preCell, NewCell(network).ID)
+		newSynapse := network.linkCells(preCell, NewCell(network).ID)
+		// inhibitory
+		newSynapse.Millivolts = -int16(math.Abs(float64(newSynapse.Millivolts)))
 	}
 }

--- a/potential/firingvocabunit.go
+++ b/potential/firingvocabunit.go
@@ -61,21 +61,6 @@ func (vu *VocabUnit) InitRandomInputs(network *Network) {
 	}
 }
 
-/*
-expandInputs expands an input firing pattern by a set number of cells and uses
-an excitatory synapse to link them.
-*/
-func expandInputs(network *Network, fp FiringPattern) {
-	for i := 0; i < laws.InputCellDifferentiationCount; i++ {
-		preCell := randCellFromFP(fp)
-		newCell := NewCell(network)
-		newSynapse := network.linkCells(preCell, newCell.ID)
-		// excitatory
-		newSynapse.Millivolts = int16(math.Abs(float64(newSynapse.Millivolts)))
-		// fp[newCell.ID] = true
-	}
-}
-
 func randCellFromFP(cellMap FiringPattern) (randCellID CellID) {
 	iterate := randomIntBetween(0, len(cellMap)-1)
 	i := 0
@@ -90,11 +75,29 @@ func randCellFromFP(cellMap FiringPattern) (randCellID CellID) {
 }
 
 /*
+expandInputs expands an input firing pattern by a set number of cells and uses
+an excitatory synapse to link them.
+*/
+func expandInputs(network *Network, fp FiringPattern) {
+	for i := 0; i < laws.InputCellDifferentiationCount; i++ {
+		preCell1 := randCellFromFP(fp)
+		preCell2 := randCellFromFP(fp)
+		newCell := NewCell(network)
+
+		newSynapse1 := network.linkCells(preCell1, newCell.ID)
+		newSynapse2 := network.linkCells(preCell2, newCell.ID)
+		// excitatory
+		newSynapse1.Millivolts = int16(math.Abs(float64(newSynapse1.Millivolts)))
+		newSynapse2.Millivolts = int16(math.Abs(float64(newSynapse2.Millivolts)))
+		// fp[newCell.ID] = true
+	}
+}
+
+/*
 expandOutputs expands an output firing pattern by adding more INHIBITORY
 synapses to new cells that are attached to random cells in its map.
 */
-func expandOutputs(network *Network, noiseLevel float64, fp FiringPattern) {
-	noisyCellsToAdd := int(math.Ceil(noiseLevel * float64(len(fp))))
+func expandOutputs(network *Network, noisyCellsToAdd int, fp FiringPattern) {
 	for i := 0; i < noisyCellsToAdd; i++ {
 		preCell := randCellFromFP(fp)
 		newSynapse := network.linkCells(preCell, NewCell(network).ID)

--- a/potential/network.go
+++ b/potential/network.go
@@ -36,18 +36,7 @@ type Network struct {
 	Cells        []*Cell
 	CellIDCursor int
 	cellMux      sync.Mutex
-
-	// private
-
-	// nextSynapsesToActivate will fire their axon cell on the next step. always true
-	nextSynapsesToActivate map[SynapseID]bool
-
-	resetCellsOnNextStep map[CellID]bool
 }
-
-// storeBlockSize is how much to increase the fixed array size of the store
-// (Cells or Synapses)
-const storeBlockSize = 5000
 
 /*
 NewNetwork is a constructor that, which also happens to reset the random number generator
@@ -58,8 +47,6 @@ func NewNetwork() *Network {
 		Disabled: false,
 		Synapses: make([]*Synapse, 0),
 		Cells:    make([]*Cell, 0),
-		nextSynapsesToActivate: make(map[SynapseID]bool),
-		resetCellsOnNextStep:   make(map[CellID]bool),
 	}
 	return &n
 }
@@ -175,8 +162,10 @@ func (network *Network) ResetForTraining() {
 		cell.activating = false
 		cell.WasFired = false
 	}
-	network.nextSynapsesToActivate = make(map[SynapseID]bool)
-	network.resetCellsOnNextStep = make(map[CellID]bool)
+	for _, synapse := range network.Synapses {
+		synapse.fireNextRound = false
+	}
+
 	network.Disabled = false
 }
 

--- a/potential/network.go
+++ b/potential/network.go
@@ -150,16 +150,13 @@ func (network *Network) RandomCellKey() (randCellID CellID) {
 /*
 ResetForTraining resets transient properties on the network to their base
 resting state.
-
-DOES NOT reset voltage or activation history; this is part of the network's
-memory at work.
 */
 func (network *Network) ResetForTraining() {
 	for _, cell := range network.Cells {
 		if cell == nil {
 			continue
 		}
-		cell.activating = false
+		cell.postRefractoryReset()
 		cell.WasFired = false
 	}
 	for _, synapse := range network.Synapses {

--- a/potential/network_test.go
+++ b/potential/network_test.go
@@ -1,10 +1,11 @@
 package potential
 
 import (
-	"github.com/ruffrey/nurtrace/laws"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/ruffrey/nurtrace/laws"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -154,7 +155,7 @@ func Test_LinkCells(t *testing.T) {
 }
 
 func Test_ResetForTraining(t *testing.T) {
-	t.Run("resets cell props activating, wasFired, but NOT voltage", func(t *testing.T) {
+	t.Run("resets cell props activating, wasFired, and voltage", func(t *testing.T) {
 		network := NewNetwork()
 
 		// pretest
@@ -165,7 +166,7 @@ func Test_ResetForTraining(t *testing.T) {
 
 		// setup
 		cell1.activating = true
-		cell1.Voltage = int16(100)
+		cell1.Voltage = int16(laws.CellRestingVoltage)
 		cell1.WasFired = true
 
 		network.Cells[cell1.ID] = cell1
@@ -174,7 +175,7 @@ func Test_ResetForTraining(t *testing.T) {
 
 		// assertions
 		assert.Equal(t, false, cell1.activating)
-		assert.Equal(t, int16(100), cell1.Voltage)
+		assert.Equal(t, int16(laws.CellRestingVoltage), cell1.Voltage)
 		assert.Equal(t, false, cell1.WasFired)
 	})
 

--- a/potential/networkstep.go
+++ b/potential/networkstep.go
@@ -68,7 +68,6 @@ func (network *Network) Step() (hasMore bool) {
 		// adding more for the next round.
 		syn.fireNextRound = false
 	}
-
 	// see if any cells fired
 	for cellID, fg := range voltageTallies {
 		cell := network.GetCell(cellID)

--- a/potential/networkstep.go
+++ b/potential/networkstep.go
@@ -46,7 +46,6 @@ func (network *Network) Step() (hasMore bool) {
 	voltageTallies := make(map[CellID]*firingGroup)
 
 	// tally up all the synapse voltage results they will have on the cells
-	// fmt.Println("nextSynapsesToActivate=", len(network.nextSynapsesToActivate))
 	for _, syn := range network.Synapses {
 		if !syn.fireNextRound {
 			continue
@@ -91,9 +90,8 @@ func (network *Network) Step() (hasMore bool) {
 
 	// for the cells from the last step, make them fire-able again
 	for cellID, cell := range network.Cells {
-		cell.Voltage = laws.CellRestingVoltage
 		if cell.activating {
-			cell.activating = false
+			cell.postRefractoryReset()
 		} else if nextCellResets[CellID(cellID)] {
 			cell.activating = true
 		}

--- a/potential/networkstep_test.go
+++ b/potential/networkstep_test.go
@@ -1,8 +1,47 @@
 package potential
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func Test_NetworkStep(t *testing.T) {
+	t.Run("postsynaptic cells of flagged synapses get flagged as activating", func(t *testing.T) {
+		network := NewNetwork()
+		cell := NewCell(network)
+		receiverCellA := NewCell(network)
+		receiverCellB := NewCell(network)
+
+		// setup two synapses, from cell to each receiver
+		network.linkCells(cell.ID, receiverCellA.ID)
+		network.linkCells(cell.ID, receiverCellB.ID)
+
+		network.GetSyn(0).fireNextRound = true
+		network.GetSyn(1).fireNextRound = true
+
+		// some pretesting
+		assert.Equal(t, false, receiverCellA.activating)
+		assert.Equal(t, false, receiverCellB.activating)
+
+		// actual test
+		hasMore := network.Step()
+
+		assert.Equal(t, false, hasMore,
+			"should not be another round to fire")
+
+		// Now the cells are activating
+		assert.Equal(t, true, receiverCellA.activating,
+			"cell is not flagged as activating after Step")
+		assert.Equal(t, true, receiverCellB.activating,
+			"cell is not flagged as activating after Step")
+
+		// and the synapses have been reset
+		assert.Equal(t, false, network.GetSyn(0).fireNextRound,
+			"synapse has not been reset for firing after Step")
+		assert.Equal(t, false, network.GetSyn(1).fireNextRound,
+			"synapse has not been reset for firing after Step")
+	})
 	t.Skip("when firing one round results in firing the next round it returns true")
 	t.Skip("when firing one round results in no new firings it returns false")
 }

--- a/potential/sample.go
+++ b/potential/sample.go
@@ -1,10 +1,7 @@
 package potential
 
 import (
-	"fmt"
 	"strings"
-
-	"github.com/ruffrey/nurtrace/laws"
 )
 
 /*
@@ -21,16 +18,11 @@ func Sample(seedText string, vocab *Vocabulary) (output string) {
 	vocab.AddTrainingData(charArray)
 
 	// fire the samples, not resetting in between (?)
-
-	fmt.Println(vocab.Outputs)
 	for _, s := range vocab.Samples {
-		var finalPattern FiringPattern
 		// fire the input a bunch of times. after that we can consider
 		// the output pattern as fired. set the output pattern.
 		inputs := vocab.Inputs[s.input].InputCells
-		for i := 0; i < laws.FiringIterationsPerSample; i++ {
-			finalPattern = mergeFiringPatterns(finalPattern, FireNetworkUntilDone(vocab.Net, inputs))
-		}
+		finalPattern := FireNetworkUntilDone(vocab.Net, inputs)
 		closest := FindClosestOutputCollection(finalPattern, vocab)
 		output += string(closest.Value)
 	}

--- a/potential/synapse.go
+++ b/potential/synapse.go
@@ -29,6 +29,7 @@ type Synapse struct {
 	FromNeuronAxon    CellID
 	ToNeuronDendrite  CellID
 	ActivationHistory uint `json:"-"` // unnecessary to recreate synapse
+	fireNextRound     bool
 }
 
 /*
@@ -41,9 +42,10 @@ func NewSynapse(network *Network) *Synapse {
 
 	network.synMux.Lock()
 	s := Synapse{
-		ID:         SynapseID(len(network.Synapses)),
-		Network:    network,
-		Millivolts: mv,
+		ID:            SynapseID(len(network.Synapses)),
+		Network:       network,
+		Millivolts:    mv,
+		fireNextRound: false,
 	}
 	synapse := &s
 	network.Synapses = append(network.Synapses, synapse)

--- a/potential/trainer.go
+++ b/potential/trainer.go
@@ -206,7 +206,13 @@ func Train(masterVocab *Vocabulary, isRemoteWorkerWithTag string) {
 	for {
 		select {
 		case vocab := <-chSynchVocab:
+			fmt.Println("masterVocab.Outputs BEFORE")
+			masterVocab.printOutputs()
+			fmt.Println("--------")
 			mergeAllOutputs(masterVocab.Outputs, vocab.Outputs)
+			fmt.Println("masterVocab.Outputs AFTER")
+			masterVocab.printOutputs()
+			fmt.Println("--------")
 
 			oDiff := DiffNetworks(masterVocab.Net, vocab.Net)
 			ApplyDiff(oDiff, masterVocab.Net)

--- a/potential/trainer.go
+++ b/potential/trainer.go
@@ -87,7 +87,9 @@ The Inputs should already be setup, before training. However the Outputs
 will change, so they should be merged along with the network merge.
 */
 func Train(masterVocab *Vocabulary, isRemoteWorkerWithTag string) {
-	shouldDedupe := isRemoteWorkerWithTag == ""
+	// TODO: deduping is turned off because of #40
+	shouldDedupe := false
+	// shouldDedupe := isRemoteWorkerWithTag == ""
 	if shouldDedupe {
 		isRemoteWorkerWithTag = "<local>"
 	}
@@ -206,13 +208,7 @@ func Train(masterVocab *Vocabulary, isRemoteWorkerWithTag string) {
 	for {
 		select {
 		case vocab := <-chSynchVocab:
-			fmt.Println("masterVocab.Outputs BEFORE")
-			masterVocab.printOutputs()
-			fmt.Println("--------")
 			mergeAllOutputs(masterVocab.Outputs, vocab.Outputs)
-			fmt.Println("masterVocab.Outputs AFTER")
-			masterVocab.printOutputs()
-			fmt.Println("--------")
 
 			oDiff := DiffNetworks(masterVocab.Net, vocab.Net)
 			ApplyDiff(oDiff, masterVocab.Net)


### PR DESCRIPTION
Instead of tracking cells to fire on the next `network.Step()` in a map on the network, they are now tracked on each cell itself.

There are several tweaks to the laws to try to get things less stuck with the same ratios during firing, but that was not fully successful.

Deduping is temporarily disabled because it causes network integrity problems (#40).